### PR TITLE
Add Halcyon to client list

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@
 * [Mastalab](https://github.com/stom79/mastalab) - Android client.
 * [Pinafore](https://github.com/nolanlawson/pinafore) - An alternative web client for Mastodon, focused on speed and simplicity.
 * [Brutaldon](https://github.com/jfmcbrayer/brutaldon) - Brutaldon is a brutalist, Web 1.0 web interface for Mastodon.
+* [Halcyon](https://notabug.org/halcyon-suite/halcyon) - A alternative web client for Mastodon and Pleroma which looks like Twitter.
 
 ## Tools
 


### PR DESCRIPTION
The alternative webclient Halcyon which aims to recreate the user interface of Twitter was missing in the client list.I added it now.