### PR TITLE
Added Mastodon Toot Bookmarklet

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@
 * [Last](https://framagit.org/luc/last) - Aggregate toots on a web page providing Atom feed and an epub (Perl).
 * [Mastodon Tags Explorer](https://mastodon-tags-explorer.hcxp.co/tags) - Explore what's currently trending in Mastodon network.
 * [Forget](https://forget.codl.fr/about/) - Delete toots after a user defined period of time (Python [source code](https://github.com/codl/forget/)).
+* [Mastodon Toot Bookmarklet](https://rmlewisuk.github.io/mastodon-toot-bookmarklet/) - A bookmarklet to toot the current page.
 
 ## User styles
 


### PR DESCRIPTION
Added Mastodon Toot Bookmarklet
- Page: https://rmlewisuk.github.io/mastodon-toot-bookmarklet/
- Source: https://github.com/rmlewisuk/mastodon-toot-bookmarklet

I added it to "tools" which seemed appropriate, but let me know if you think a different category would be better and I can update/fix it.

