### PR TITLE
Add link to Planiverse

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@
 * [Pinafore](https://github.com/nolanlawson/pinafore) - Alternative web client for Mastodon, focused on speed and simplicity.
 * [Brutaldon](https://github.com/jfmcbrayer/brutaldon) - Brutaldon is a brutalist, Web 1.0 web interface for Mastodon.
 * [Halcyon](https://notabug.org/halcyon-suite/halcyon) - Alternative web client for Mastodon and Pleroma with a Twitter-like interface.
+* [Planiverse](https://github.com/FuzzJunket/planiverse) - A minimalist, no-JS Web client for Mastodon.
 
 ## Tools
 


### PR DESCRIPTION
Added a link to Planiverse, a minimalist, no-JS Web client:
https://github.com/FuzzJunket/planiverse