### PR TITLE
Add link to Mast for iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@
 * [Pinafore](https://github.com/nolanlawson/pinafore) - Alternative web client for Mastodon, focused on speed and simplicity.
 * [Brutaldon](https://github.com/jfmcbrayer/brutaldon) - Brutaldon is a brutalist, Web 1.0 web interface for Mastodon.
 * [Halcyon](https://notabug.org/halcyon-suite/halcyon) - Alternative web client for Mastodon and Pleroma with a Twitter-like interface.
+* [Mast](https://itunes.apple.com/gb/app/mast/id1437429129) - A beautiful Mastodon app for iOS and  Watch.
 
 ## Tools
 


### PR DESCRIPTION
Adds **Mast** iOS App Store link to list of clients.

More about **Mast**:
🐘️ App Store - https://itunes.apple.com/gb/app/mast/id1437429129
🐘️ Product Hunt - https://www.producthunt.com/posts/mast-2
🐘️ Twitter - https://twitter.com/TheMastApp

![](https://is1-ssl.mzstatic.com/image/thumb/Purple118/v4/8d/53/e2/8d53e220-938a-c7c3-f31e-3b099190d059/pr_source.png/460x0w.jpg)