### PR TITLE
Added Mastodon Explorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@
 * [Mastodon Tags Explorer](https://mastodon-tags-explorer.hcxp.co/tags) - Explore what's currently trending in Mastodon network.
 * [Forget](https://forget.codl.fr/about/) - Delete toots after a user defined period of time (Python [source code](https://github.com/codl/forget/)).
 * [Mastodon Toot Bookmarklet](https://rmlewisuk.github.io/mastodon-toot-bookmarklet/) - Bookmarklet to toot the current page ([source code](https://github.com/rmlewisuk/mastodon-toot-bookmarklet/))
+* [Mastodon Explorer](https://mastodon-explorer.netlify.com/) - Trending hashtags and popular toots, regenerated every hour.
 
 ## User styles
 


### PR DESCRIPTION
Find people to follow across the fediverse!

Static site regenerated every hour. It scrapes the /explore of every safe mastodon instance on 2.7 and pulls down recent toots of popular tags. I even made the follow, like and reblog links work.

I also made it not show images for posts marked sensitive.