### PR TITLE
Update Mastalab link to the renamed Fedilab

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@
 * [naumanni](https://github.com/naumanni/naumanni) - Web user interface specially designed for Mastodon.
 * [Tooter](https://github.com/dysk0/harbour-tooter) - Native client for SailfishOS.
 * [Tootdon](http://tootdon.club) - Fully featured client for iOS and Android.
-* [Mastalab](https://github.com/stom79/mastalab) - Android client.
+* [Fedilab](https://framagit.org/tom79/fedilab) - Android client.
 * [Pinafore](https://github.com/nolanlawson/pinafore) - Alternative web client for Mastodon, focused on speed and simplicity.
 * [Brutaldon](https://github.com/jfmcbrayer/brutaldon) - Brutaldon is a brutalist, Web 1.0 web interface for Mastodon.
 * [Halcyon](https://notabug.org/halcyon-suite/halcyon) - Alternative web client for Mastodon and Pleroma with a Twitter-like interface.


### PR DESCRIPTION
Mastalab was renamed to Fedilab, and it's github source has been moved te the GitLab instance at Framagit.
Updated text and link accordingly.