### PR TITLE
Add nowplaying.resynth1943.net

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@
 * [Mastodon Toot Bookmarklet](https://rknightuk.github.io/mastodon-toot-bookmarklet/) - Bookmarklet to toot the current page ([source code](https://github.com/rknightuk/mastodon-toot-bookmarklet/))
 * [Mastodon – Simplified Federation!](https://addons.mozilla.org/firefox/addon/mastodon-simplified-federation/) - Redirect clicks on remote follow/interaction buttons to your own instance ([source code](https://github.com/rugk/mastodon-simplified-federation)).
 * [Fediverse Explorer](https://fediverse.0qz.fun/) - Trending hashtags and popular toots, regenerated every hour.
+* [Mastodon #nowplaying Toot Bookmarklet](https://nowplaying.resynth1943.net) - Bookmarklet to toot the music you're currently listening to. Works with YouTube. ([source code](https://github.com/resynth1943/mastodon-nowplaying-toot-bookmarklet))
 
 
 ## User styles


### PR DESCRIPTION
It's basically a bookmarklet creator adapted from Mastodon Toot Bookmarklet.
This one automatically appends #nowplaying and removes the '- YouTube' from
the document title. This was made really quickly, but it works very well for the 
music-sharing crowd on the fediverse. This isn't a replacement for a scrobbler
which would automatically do this, but it's something :-)